### PR TITLE
Bug Fix: get_price_history() doesn't check for token validity prior to execute the get.

### DIFF
--- a/examples/test_api.py
+++ b/examples/test_api.py
@@ -37,6 +37,7 @@ def main():
     client_id = os.getenv('SCHWAB_CLIENT_ID')
     client_secret = os.getenv('SCHWAB_CLIENT_SECRET')
 
+
     # Enhanced environment variable check
     if not client_id or not client_secret:
         raise ValueError("SCHWAB_CLIENT_ID and SCHWAB_CLIENT_SECRET must be set as environment variables")


### PR DESCRIPTION
## Steps to reproduce

1. Call get_price_history method
2. Continue to do so beyond token expiration

actual
* a 401 error is raised

expected
* the token is refreshed and then the call is executed

## Additional Features

* enhanced retry logic for specific HTTPErrors
* added unit test for 401 exception.